### PR TITLE
feat/env vars: moving from config json to env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# This is just an example file for your environment.
+# You should copy this file to .env and fill in the values.
+
+################################################
+## DO NOT COMMIT THIS FILE TO VERSION CONTROL ##
+## THIS FILE CONTAINS SECRET KEYS AND TOKENS  ##
+################################################
+
+# Discord Config
+DISCORD_APP_ID=0
+DISCORD_CLIENT_ID=0
+DISCORD_CLIENT_SECRET=0
+DISCORD_BOT_TOKEN=0
+DISCORD_DEV_GUILD_ID=0
+DISCORD_OWNER_ID=0
+
+# General Config
+LOG_LEVEL=DEBUG # trace, debug, info, warn, error
+GO_ENV=development # development, production

--- a/cmd/sentinel/main.go
+++ b/cmd/sentinel/main.go
@@ -1,62 +1,72 @@
 package main
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/avvo-na/forkman/api/router"
 	"github.com/avvo-na/forkman/common/logger"
 	"github.com/avvo-na/forkman/config"
+	"github.com/avvo-na/forkman/discord"
 	"github.com/go-playground/validator/v10"
 )
 
 func main() {
 	// Main deps for application
-	validator.New(validator.WithRequiredStructEnabled())
+	valid := validator.New(validator.WithRequiredStructEnabled())
 	cfg := config.New()
-	logger.New(cfg.GoEnv)
+	log := logger.New(cfg.GoEnv)
 
-	// // Create a new Discord bot
-	// disco := discord.New(cfg, log)
-	// disco.Setup()
-	// err := disco.Open()
-	// defer disco.Close()
-	// if err != nil {
-	// 	panic(err)
-	// }
-	//
-	// // Init new http server :D
-	// r := router.New(log, valid, disco)
-	// s := &http.Server{
-	// 	Addr:    ":8080", // TODO: Make this configurable
-	// 	Handler: r,
-	// }
-	//
-	// // Wait for CTRL+C (sigterm)
-	// closed := make(chan struct{})
-	// go func() {
-	// 	sigint := make(chan os.Signal, 1)
-	// 	signal.Notify(sigint, os.Interrupt, syscall.SIGTERM)
-	// 	<-sigint
-	//
-	// 	log.Info().Msgf("Shutting down server %v", s.Addr)
-	//
-	// 	ctx, cancel := context.WithTimeout(
-	// 		context.Background(),
-	// 		1000*time.Millisecond, // TODO: Make this configurable
-	// 	)
-	// 	defer cancel()
-	//
-	// 	if err := s.Shutdown(ctx); err != nil {
-	// 		log.Error().Err(err).Msg("Server shutdown failure!")
-	// 	}
-	//
-	// 	// TODO: once we have a db, we should also close it here
-	//
-	// 	close(closed)
-	// }()
-	//
-	// log.Info().Msgf("Starting server %v", s.Addr)
-	// if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-	// 	log.Fatal().Err(err).Msg("Server startup failure")
-	// }
-	//
-	// <-closed
-	// log.Info().Msgf("Server shutdown successfully")
+	// Create a new Discord bot
+	disco := discord.New(cfg, log)
+	disco.Setup()
+	err := disco.Open()
+	defer disco.Close()
+	if err != nil {
+		panic(err)
+	}
+
+	// Init new http server :D
+	r := router.New(log, valid, disco)
+	s := &http.Server{
+		Addr:    fmt.Sprintf(":%d", cfg.ServerPort),
+		Handler: r,
+	}
+
+	// Wait for sigterm (Ctrl+C)
+	closed := make(chan struct{})
+	go func() {
+		sigint := make(chan os.Signal, 1)
+		signal.Notify(sigint, os.Interrupt, syscall.SIGTERM)
+		<-sigint
+
+		log.Info().Msgf("Shutting down server %v", s.Addr)
+
+		ctx, cancel := context.WithTimeout(
+			context.Background(),
+			1000*time.Millisecond, // TODO: Make this configurable
+		)
+		defer cancel()
+
+		if err := s.Shutdown(ctx); err != nil {
+			log.Error().Err(err).Msg("Server shutdown failure!")
+		}
+
+		// TODO: once we have a db, we should also close it here
+
+		close(closed)
+	}()
+
+	log.Info().Msgf("Starting server %v", s.Addr)
+	if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatal().Err(err).Msg("Server startup failure")
+	}
+
+	<-closed
+	log.Info().Msgf("Server shutdown successfully")
 }

--- a/cmd/sentinel/main.go
+++ b/cmd/sentinel/main.go
@@ -1,71 +1,62 @@
 package main
 
 import (
-	"context"
-	"net/http"
-	"os"
-	"os/signal"
-	"syscall"
-	"time"
-
-	"github.com/avvo-na/forkman/api/router"
 	"github.com/avvo-na/forkman/common/logger"
 	"github.com/avvo-na/forkman/config"
-	"github.com/avvo-na/forkman/discord"
 	"github.com/go-playground/validator/v10"
 )
 
 func main() {
 	// Main deps for application
-	valid := validator.New(validator.WithRequiredStructEnabled())
-	cfg := config.New(valid)
-	log := logger.New(cfg)
+	validator.New(validator.WithRequiredStructEnabled())
+	cfg := config.New()
+	logger.New(cfg.GoEnv)
 
-	// Create a new Discord bot
-	disco := discord.New(cfg, log)
-	disco.Setup()
-	err := disco.Open()
-	defer disco.Close()
-	if err != nil {
-		panic(err)
-	}
-
-	// Init new http server :D
-	r := router.New(log, valid, disco)
-	s := &http.Server{
-		Addr:    ":8080", // TODO: Make this configurable
-		Handler: r,
-	}
-
-	// Wait for CTRL+C (sigterm)
-	closed := make(chan struct{})
-	go func() {
-		sigint := make(chan os.Signal, 1)
-		signal.Notify(sigint, os.Interrupt, syscall.SIGTERM)
-		<-sigint
-
-		log.Info().Msgf("Shutting down server %v", s.Addr)
-
-		ctx, cancel := context.WithTimeout(
-			context.Background(),
-			1000*time.Millisecond, // TODO: Make this configurable
-		)
-		defer cancel()
-
-		if err := s.Shutdown(ctx); err != nil {
-			log.Error().Err(err).Msg("Server shutdown failure!")
-		}
-
-		// TODO: once we have a db, we should also close it here
-
-		close(closed)
-	}()
-
-	log.Info().Msgf("Starting server %v", s.Addr)
-	if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		log.Fatal().Err(err).Msg("Server startup failure")
-	}
-
-	<-closed
-	log.Info().Msgf("Server shutdown successfully")
+	// // Create a new Discord bot
+	// disco := discord.New(cfg, log)
+	// disco.Setup()
+	// err := disco.Open()
+	// defer disco.Close()
+	// if err != nil {
+	// 	panic(err)
+	// }
+	//
+	// // Init new http server :D
+	// r := router.New(log, valid, disco)
+	// s := &http.Server{
+	// 	Addr:    ":8080", // TODO: Make this configurable
+	// 	Handler: r,
+	// }
+	//
+	// // Wait for CTRL+C (sigterm)
+	// closed := make(chan struct{})
+	// go func() {
+	// 	sigint := make(chan os.Signal, 1)
+	// 	signal.Notify(sigint, os.Interrupt, syscall.SIGTERM)
+	// 	<-sigint
+	//
+	// 	log.Info().Msgf("Shutting down server %v", s.Addr)
+	//
+	// 	ctx, cancel := context.WithTimeout(
+	// 		context.Background(),
+	// 		1000*time.Millisecond, // TODO: Make this configurable
+	// 	)
+	// 	defer cancel()
+	//
+	// 	if err := s.Shutdown(ctx); err != nil {
+	// 		log.Error().Err(err).Msg("Server shutdown failure!")
+	// 	}
+	//
+	// 	// TODO: once we have a db, we should also close it here
+	//
+	// 	close(closed)
+	// }()
+	//
+	// log.Info().Msgf("Starting server %v", s.Addr)
+	// if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	// 	log.Fatal().Err(err).Msg("Server startup failure")
+	// }
+	//
+	// <-closed
+	// log.Info().Msgf("Server shutdown successfully")
 }

--- a/common/logger/logger.go
+++ b/common/logger/logger.go
@@ -11,9 +11,9 @@ import (
 
 func New(goEnv string) *zerolog.Logger {
 	switch goEnv {
-	case "dev":
+	case "development":
 		return dev(goEnv)
-	case "prod":
+	case "production":
 		return prod(goEnv)
 	default:
 		panic("Unknown environment, please check your configuration file")

--- a/common/logger/logger.go
+++ b/common/logger/logger.go
@@ -6,24 +6,21 @@ import (
 	"strings"
 	"time"
 
-	"github.com/avvo-na/forkman/config"
 	"github.com/rs/zerolog"
 )
 
-func New(c *config.ConfigManager) *zerolog.Logger {
-	cfg := c.GetAppConfig()
-
-	switch cfg.Environment {
+func New(goEnv string) *zerolog.Logger {
+	switch goEnv {
 	case "dev":
-		return dev(cfg)
+		return dev(goEnv)
 	case "prod":
-		return prod(cfg)
+		return prod(goEnv)
 	default:
 		panic("Unknown environment, please check your configuration file")
 	}
 }
 
-func dev(c config.AppConfig) *zerolog.Logger {
+func dev(goEnv string) *zerolog.Logger {
 	// Default to console output
 	output := zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339}
 	output.NoColor = false
@@ -95,32 +92,12 @@ func dev(c config.AppConfig) *zerolog.Logger {
 	}
 
 	// Initialize the logger
-	logger := zerolog.New(output).With().Timestamp().Caller().Logger()
-
-	// Add the level
-	switch c.LogLevel {
-	case "trace":
-		logger = logger.Level(zerolog.TraceLevel)
-	case "debug":
-		logger = logger.Level(zerolog.DebugLevel)
-	case "info":
-		logger = logger.Level(zerolog.InfoLevel)
-	case "warn":
-		logger = logger.Level(zerolog.WarnLevel)
-	case "error":
-		logger = logger.Level(zerolog.ErrorLevel)
-	case "fatal":
-		logger = logger.Level(zerolog.FatalLevel)
-	case "panic":
-		logger = logger.Level(zerolog.PanicLevel)
-	default:
-		logger = logger.Level(zerolog.InfoLevel)
-	}
+	logger := zerolog.New(output).With().Timestamp().Caller().Logger().Level(zerolog.DebugLevel)
 
 	return &logger
 }
 
 // TODO: impl production logger, will just be json output
-func prod(c config.AppConfig) *zerolog.Logger {
+func prod(goEnv string) *zerolog.Logger {
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1,19 +1,25 @@
 package config
 
 import (
+	"time"
+
 	"github.com/caarlos0/env/v11"
 	"github.com/joho/godotenv"
 )
 
 type Config struct {
-	DiscordAppID        string `env:"DISCORD_APP_ID,required,notEmpty"`
-	DiscordClientID     string `env:"DISCORD_CLIENT_ID,required,notEmpty"`
-	DiscordClientSecret string `env:"DISCORD_CLIENT_SECRET,required,notEmpty"`
-	DiscordBotToken     string `env:"DISCORD_BOT_TOKEN,required,notEmpty"`
-	DiscordDevGuildID   string `env:"DISCORD_DEV_GUILD_ID,required,notEmpty"`
-	DiscordOwnerID      string `env:"DISCORD_OWNER_ID,required,notEmpty"`
-	LogLevel            string `env:"LOG_LEVEL,required,notEmpty"`
-	GoEnv               string `env:"GO_ENV,required,notEmpty"`
+	DiscordAppID        string        `env:"DISCORD_APP_ID,required,notEmpty"`
+	DiscordClientID     string        `env:"DISCORD_CLIENT_ID,required,notEmpty"`
+	DiscordClientSecret string        `env:"DISCORD_CLIENT_SECRET,required,notEmpty"`
+	DiscordBotToken     string        `env:"DISCORD_BOT_TOKEN,required,notEmpty"`
+	DiscordDevGuildID   string        `env:"DISCORD_DEV_GUILD_ID,required,notEmpty"`
+	DiscordOwnerID      string        `env:"DISCORD_OWNER_ID,required,notEmpty"`
+	ServerPort          int           `env:"SERVER_PORT,required,notEmpty"`
+	ServerTimeoutRead   time.Duration `env:"SERVER_TIMEOUT_READ,required,notEmpty"`
+	ServerTimeoutWrite  time.Duration `env:"SERVER_TIMEOUT_WRITE,required,notEmpty"`
+	ServerTimeoutIdle   time.Duration `env:"SERVER_TIMEOUT_IDLE,required,notEmpty"`
+	LogLevel            string        `env:"LOG_LEVEL,required,notEmpty"`
+	GoEnv               string        `env:"GO_ENV,required,notEmpty"`
 }
 
 func New() *Config {

--- a/config/config.go
+++ b/config/config.go
@@ -5,14 +5,14 @@ import (
 )
 
 type Config struct {
-	DiscordAppID        string `env:"DISCORD_APP_ID, required"`
-	DiscordClientID     string `env:"DISCORD_CLIENT_ID, required"`
-	DiscordClientSecret string `env:"DISCORD_CLIENT_SECRET, required"`
-	DiscordBotToken     string `env:"DISCORD_BOT_TOKEN, required"`
-	DiscordDevGuildID   string `env:"DISCORD_DEV_GUILD_ID, required"`
-	DiscordOwnerID      string `env:"DISCORD_OWNER_ID, required"`
-	LogLevel            string `env:"LOG_LEVEL, default=info"`
-	GoEnv               string `env:"GO_ENV, default=dev"`
+	DiscordAppID        string `env:"DISCORD_APP_ID required"`
+	DiscordClientID     string `env:"DISCORD_CLIENT_ID required"`
+	DiscordClientSecret string `env:"DISCORD_CLIENT_SECRET required"`
+	DiscordBotToken     string `env:"DISCORD_BOT_TOKEN required"`
+	DiscordDevGuildID   string `env:"DISCORD_DEV_GUILD_ID required"`
+	DiscordOwnerID      string `env:"DISCORD_OWNER_ID required"`
+	LogLevel            string `env:"LOG_LEVEL default=info"`
+	GoEnv               string `env:"GO_ENV default=development"`
 }
 
 func New() *Config {

--- a/config/config.go
+++ b/config/config.go
@@ -2,20 +2,26 @@ package config
 
 import (
 	"github.com/caarlos0/env/v11"
+	"github.com/joho/godotenv"
 )
 
 type Config struct {
-	DiscordAppID        string `env:"DISCORD_APP_ID required"`
-	DiscordClientID     string `env:"DISCORD_CLIENT_ID required"`
-	DiscordClientSecret string `env:"DISCORD_CLIENT_SECRET required"`
-	DiscordBotToken     string `env:"DISCORD_BOT_TOKEN required"`
-	DiscordDevGuildID   string `env:"DISCORD_DEV_GUILD_ID required"`
-	DiscordOwnerID      string `env:"DISCORD_OWNER_ID required"`
-	LogLevel            string `env:"LOG_LEVEL default=info"`
-	GoEnv               string `env:"GO_ENV default=development"`
+	DiscordAppID        string `env:"DISCORD_APP_ID,required,notEmpty"`
+	DiscordClientID     string `env:"DISCORD_CLIENT_ID,required,notEmpty"`
+	DiscordClientSecret string `env:"DISCORD_CLIENT_SECRET,required,notEmpty"`
+	DiscordBotToken     string `env:"DISCORD_BOT_TOKEN,required,notEmpty"`
+	DiscordDevGuildID   string `env:"DISCORD_DEV_GUILD_ID,required,notEmpty"`
+	DiscordOwnerID      string `env:"DISCORD_OWNER_ID,required,notEmpty"`
+	LogLevel            string `env:"LOG_LEVEL,required,notEmpty"`
+	GoEnv               string `env:"GO_ENV,required,notEmpty"`
 }
 
 func New() *Config {
+	err := godotenv.Load()
+	if err != nil {
+		panic(err)
+	}
+
 	cfg, err := env.ParseAs[Config]()
 	if err != nil {
 		panic(err)

--- a/config/config.go
+++ b/config/config.go
@@ -1,168 +1,25 @@
 package config
 
 import (
-	"encoding/json"
-	"fmt"
-	"os"
-	"sync"
-
-	"github.com/go-playground/validator/v10"
+	"github.com/caarlos0/env/v11"
 )
-
-type AppConfig struct {
-	DiscordAppID        string `json:"discord_app_id"        validate:"required"`
-	DiscordClientID     string `json:"discord_client_id"     validate:"required"`
-	DiscordClientSecret string `json:"discord_client_secret" validate:"required"`
-	DiscordBotToken     string `json:"discord_bot_token"     validate:"required"`
-	DiscordDevGuildID   string `json:"discord_dev_guild_id"  validate:"required"`
-	DiscordOwnerID      string `json:"discord_owner_id"      validate:"required"`
-	LogLevel            string `json:"log_level"             validate:"required"`
-	Environment         string `json:"environment"           validate:"required"`
-}
-
-type UtilityConfig struct {
-	Enabled *bool `json:"enabled" validate:"required"`
-}
-
-type ModerationConfig struct {
-	Enabled *bool `json:"enabled" validate:"required"`
-}
-
-type ModuleConfig struct {
-	Utility    UtilityConfig    `json:"utility"    validate:"required"`
-	Moderation ModerationConfig `json:"moderation" validate:"required"`
-}
 
 type Config struct {
-	AppCfg    AppConfig    `json:"app"     validate:"required"`
-	ModuleCfg ModuleConfig `json:"modules" validate:"required"`
+	DiscordAppID        string `env:"DISCORD_APP_ID, required"`
+	DiscordClientID     string `env:"DISCORD_CLIENT_ID, required"`
+	DiscordClientSecret string `env:"DISCORD_CLIENT_SECRET, required"`
+	DiscordBotToken     string `env:"DISCORD_BOT_TOKEN, required"`
+	DiscordDevGuildID   string `env:"DISCORD_DEV_GUILD_ID, required"`
+	DiscordOwnerID      string `env:"DISCORD_OWNER_ID, required"`
+	LogLevel            string `env:"LOG_LEVEL, default=info"`
+	GoEnv               string `env:"GO_ENV, default=dev"`
 }
 
-type ConfigManager struct {
-	cfg *Config
-	mtx *sync.RWMutex
-	val *validator.Validate
-}
-
-// NOTE: Used to generate a default config file,
-// only happens if the config file is not found.
-var (
-	defaultCfg = Config{
-		AppCfg: AppConfig{
-			DiscordAppID:        "",
-			DiscordClientID:     "",
-			DiscordClientSecret: "",
-			DiscordBotToken:     "",
-			DiscordDevGuildID:   "",
-			DiscordOwnerID:      "",
-			LogLevel:            "info",
-			Environment:         "dev",
-		},
-		ModuleCfg: ModuleConfig{
-			Utility: UtilityConfig{
-				Enabled: new(bool),
-			},
-			Moderation: ModerationConfig{
-				Enabled: new(bool),
-			},
-		},
-	}
-)
-
-func New(v *validator.Validate) *ConfigManager {
-	file, err := os.Open("config.json")
-	if err != nil {
-		// Generate a new config file
-		file, err := os.Create("config.json")
-		if err != nil {
-			panic(err)
-		}
-		// Write the JSON to the file
-		enc := json.NewEncoder(file)
-		enc.SetIndent("", "  ")
-		enc.Encode(defaultCfg)
-
-		// Close the file
-		file.Close()
-		panic(
-			"Config file not found, one has been generated, please fill it out and restart the bot",
-		)
-	}
-
-	// Load the config file
-	cfg := Config{}
-	decoder := json.NewDecoder(file)
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&cfg)
+func New() *Config {
+	cfg, err := env.ParseAs[Config]()
 	if err != nil {
 		panic(err)
 	}
 
-	// Validate the config
-	err = v.Struct(&cfg)
-	if err != nil {
-		panic(err)
-	}
-
-	return &ConfigManager{
-		cfg: &cfg,
-		mtx: &sync.RWMutex{},
-		val: v,
-	}
-}
-
-func (c *ConfigManager) GetAppConfig() AppConfig {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
-
-	return c.cfg.AppCfg
-}
-
-func (c *ConfigManager) GetModuleConfig() ModuleConfig {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
-
-	return c.cfg.ModuleCfg
-}
-
-func (c *ConfigManager) WriteModerationConfig(cfg ModerationConfig) error {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
-
-	c.cfg.ModuleCfg.Moderation = cfg
-
-	file, err := os.Create("config.json")
-	if err != nil {
-		return fmt.Errorf("failed to open config file: %w", err)
-	}
-
-	enc := json.NewEncoder(file)
-	enc.SetIndent("", "  ")
-	err = enc.Encode(c.cfg)
-	if err != nil {
-		return fmt.Errorf("failed to encode config: %w", err)
-	}
-
-	return nil
-}
-
-func (c *ConfigManager) WriteUtilityConfig(cfg UtilityConfig) error {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
-
-	c.cfg.ModuleCfg.Utility = cfg
-
-	file, err := os.Create("config.json")
-	if err != nil {
-		return fmt.Errorf("failed to open config file: %w", err)
-	}
-
-	enc := json.NewEncoder(file)
-	enc.SetIndent("", "  ")
-	err = enc.Encode(c.cfg)
-	if err != nil {
-		return fmt.Errorf("failed to encode config: %w", err)
-	}
-
-	return nil
+	return &cfg
 }

--- a/discord/discord.go
+++ b/discord/discord.go
@@ -27,12 +27,12 @@ type Module interface {
 type Discord struct {
 	session *discordgo.Session
 	log     *zerolog.Logger
-	cfg     *config.ConfigManager
+	cfg     *config.Config
 }
 
 // TODO: Probably dont panic :P or maybe we should? idk im tired 💀
-func New(cfg *config.ConfigManager, log *zerolog.Logger) *Discord {
-	s, err := discordgo.New("Bot " + cfg.GetAppConfig().DiscordBotToken)
+func New(cfg *config.Config, log *zerolog.Logger) *Discord {
+	s, err := discordgo.New("Bot " + cfg.DiscordBotToken)
 	if err != nil {
 		panic(err)
 	}

--- a/discord/utility/utility.go
+++ b/discord/utility/utility.go
@@ -9,10 +9,10 @@ import (
 type UtilityModule struct {
 	session *discordgo.Session
 	log     *zerolog.Logger
-	cfg     *config.ConfigManager
+	cfg     *config.Config
 }
 
-func New(s *discordgo.Session, l *zerolog.Logger, c *config.ConfigManager) *UtilityModule {
+func New(s *discordgo.Session, l *zerolog.Logger, c *config.Config) *UtilityModule {
 	subLogger := l.With().Str("module", "utility").Logger()
 
 	return &UtilityModule{
@@ -27,27 +27,17 @@ func (u *UtilityModule) Name() string {
 }
 
 func (u *UtilityModule) Load() error {
-	// Grab the config
-	appCfg := u.cfg.GetAppConfig()
-	moduleCfg := u.cfg.GetModuleConfig()
-
-	// If the module is disabled, skip registration
-	if !*moduleCfg.Utility.Enabled {
-		u.log.Info().Msg("Module is disabled, skipping registration")
-		return nil
-	}
-
 	// Register all commands
 	for _, command := range commands {
 		u.log.Debug().
-			Str("appID", appCfg.DiscordAppID).
-			Str("guildID", appCfg.DiscordDevGuildID).
+			Str("appID", u.cfg.DiscordAppID).
+			Str("guildID", u.cfg.DiscordDevGuildID).
 			Str("command", command.Name).
 			Msg("Registering command")
 
 		_, err := u.session.ApplicationCommandCreate(
-			appCfg.DiscordAppID,
-			appCfg.DiscordDevGuildID,
+			u.cfg.DiscordAppID,
+			u.cfg.DiscordDevGuildID,
 			command,
 		)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 require (
 	github.com/caarlos0/env v3.5.0+incompatible // indirect
 	github.com/go-chi/chi/v5 v5.1.0 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 )
 
 require (
+	github.com/caarlos0/env v3.5.0+incompatible // indirect
 	github.com/go-chi/chi/v5 v5.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
@@ -16,6 +17,7 @@ require (
 
 require (
 	github.com/bwmarrin/discordgo v0.28.1
+	github.com/caarlos0/env/v11 v11.2.2
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/bwmarrin/discordgo v0.28.1 h1:gXsuo2GBO7NbR6uqmrrBDplPUx2T3nzu775q/Rd1aG4=
 github.com/bwmarrin/discordgo v0.28.1/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
+github.com/caarlos0/env v3.5.0+incompatible h1:Yy0UN8o9Wtr/jGHZDpCBLpNrzcFLLM2yixi/rBrKyJs=
+github.com/caarlos0/env v3.5.0+incompatible/go.mod h1:tdCsowwCzMLdkqRYDlHpZCp2UooDD3MspDBjZ2AD02Y=
+github.com/caarlos0/env/v11 v11.2.2 h1:95fApNrUyueipoZN/EhA8mMxiNxrBwDa+oAZrMWl3Kg=
+github.com/caarlos0/env/v11 v11.2.2/go.mod h1:JBfcdeQiBoI3Zh1QRAWfe+tpiNTmDtcCj/hHHHMx0vc=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=


### PR DESCRIPTION
With validation! We now support full environment variable configuration for initial server settings. These will be read only and need a server restart in order to take effect. This lets us not worry about mutexes there. Any further configuration that is needed will be done through the web dashboard.